### PR TITLE
Add per-site breakdowns to the run summary message

### DIFF
--- a/src/connector/browser.js
+++ b/src/connector/browser.js
@@ -141,6 +141,7 @@ class Browser {
                 return {
                     id: this.getUrlIdWithSiteBrowser(url, siteBrowser),
                     url: url,
+                    name: siteBrowser.name(),
                     data: data
                 };
             });

--- a/src/service/difference-notifier-service.js
+++ b/src/service/difference-notifier-service.js
@@ -7,6 +7,18 @@ const logger = newLogger('DifferenceNotifierService');
 //----------------------
 
 /**
+ * Formats a labeled total with a nested per-key breakdown, e.g.:
+ *   Skipped: 8
+ *     mercadolibre.com.ar: 5
+ *     argenprop.com: 3
+ */
+function formatBreakdown(label, countsByKey) {
+    let total = Object.values(countsByKey).reduce((sum, n) => sum + n, 0);
+    let lines = Object.entries(countsByKey).map(([key, count]) => `  ${key}: ${count}`);
+    return [`${label}: ${total}`, ...lines].join("\n");
+}
+
+/**
  * Service that exports all the given urls and compares the data against the previous exported version.
  * If any difference is found, it notifies using the notifierService
  */
@@ -22,8 +34,8 @@ class DifferenceNotifierService {
         logger.info(`Exporting ${urls.length} urls..`);
 
         let startTime = Date.now();
-        let totalSkipped = 0;
-        let totalDiffs = 0;
+        let skippedByDomain = {};
+        let diffsByBrowser = {};
         let errorsByBrowser = {};
         let promise = Promise.resolve();
         urls.forEach((url, i) => {
@@ -34,13 +46,16 @@ class DifferenceNotifierService {
                 return this.browser.fetchData(url);
             }).then(response => {
                 if (!response) { // Skip not handled urls.
-                    totalSkipped++;
+                    let domain = new URL(url).hostname;
+                    skippedByDomain[domain] = (skippedByDomain[domain] || 0) + 1;
                     return;
                 }
 
                 // Check for data changes and notify:
                 return this.verifyDataDifference(response.url, response.id, response.data).then(hadDifference => {
-                    if (hadDifference) totalDiffs++;
+                    if (hadDifference) {
+                        diffsByBrowser[response.name] = (diffsByBrowser[response.name] || 0) + 1;
+                    }
                     logger.info(`Going to save data exported for id ${response.id}`);
                     return this.fileDataRepository.createNewDataFile(response.id, response.data);
                 });
@@ -53,11 +68,10 @@ class DifferenceNotifierService {
         });
         return promise.then(() => {
             let elapsedMinutes = Math.round(((Date.now() - startTime) / 1000 / 60));
-            let totalErrors = Object.values(errorsByBrowser).reduce((sum, n) => sum + n, 0);
-            let errorsBreakdown = totalErrors > 0 ?
-                ` (${Object.entries(errorsByBrowser).map(([name, count]) => `${name}: ${count}`).join(", ")})` :
-                "";
-            let message = `Finished checking ${urls.length} urls (${totalSkipped} skipped) in ${elapsedMinutes} minutes, with ${totalDiffs} differences, and ${totalErrors} errors${errorsBreakdown}.`;
+            let message = `Finished checking ${urls.length} urls in ${elapsedMinutes} minutes.\n` +
+                formatBreakdown("Differences", diffsByBrowser) + "\n" +
+                formatBreakdown("Skipped", skippedByDomain) + "\n" +
+                formatBreakdown("Errors", errorsByBrowser);
             logger.info(message);
             return this.notifierService.notify(message);
         });

--- a/test/service/difference-notifier-service.js
+++ b/test/service/difference-notifier-service.js
@@ -98,6 +98,7 @@ describe('exportData()', function () {
         return {
             url: url,
             id: url.slice(-1),
+            name: "TestBrowser",
             data: {
                 EXPORT_VERSION: 1,
                 oldField: "oldValue",
@@ -142,7 +143,13 @@ describe('exportData()', function () {
                 ` {\n+  newField: "newValue"\n }\n`;
             sinon.assert.calledWith(notifierService.notify, expectedMessage);
 
-            expectedMessage = `Finished checking 4 urls (1 skipped) in 0 minutes, with 1 differences, and 1 errors (TestBrowser: 1).`;
+            expectedMessage = `Finished checking 4 urls in 0 minutes.\n` +
+                `Differences: 1\n` +
+                `  TestBrowser: 1\n` +
+                `Skipped: 1\n` +
+                `  example.com: 1\n` +
+                `Errors: 1\n` +
+                `  TestBrowser: 1`;
             sinon.assert.calledWith(notifierService.notify, expectedMessage);
         });
     });


### PR DESCRIPTION
## What

Reworks the end-of-run summary message (the "Finished checking … urls" notification) so it shows a per-site breakdown of differences, skipped urls, and errors instead of a single long line.

### Before
```
Finished checking 4 urls (1 skipped) in 0 minutes, with 1 differences, and 1 errors (TestBrowser: 1).
```

### After
```
Finished checking 20 urls in 2 minutes.
Differences: 4
  MercadoLibre: 3
  Argenprop: 1
Skipped: 8
  www.mercadolibre.com.ar: 5
  www.argenprop.com: 3
Errors: 2
  MercadoLibre: 2
```

## Changes
- Added a shared `formatBreakdown()` helper that prints a labeled total with an indented per-key list, reused for all three sections.
- **Differences** and **Errors** are grouped by browser/site name. To attribute differences per site, `fetchData` now includes the site browser `name` on the success response (errors already carried `siteBrowserName`).
- **Skipped** is grouped by domain (`hostname`). A skipped url is one where no site browser matched, so there's no site name available — the raw host is the best label there.

## Testing
- Updated and ran the existing `difference-notifier-service` test.
- Full suite passes (`npm test`, 17 passing).